### PR TITLE
Debian stretch: add complete Debian repositories

### DIFF
--- a/meta-isar/conf/distro/debian-stretch.conf
+++ b/meta-isar/conf/distro/debian-stretch.conf
@@ -2,6 +2,8 @@
 # Copyright (C) 2017 ilbers GmbH
 
 DISTRO_SUITE ?= "stretch"
+DISTRO_SEC_SUITE ?= "${DISTRO_SUITE}/updates"
 DISTRO_COMPONENTS ?= "main contrib non-free"
 DISTRO_APT_SOURCE ?= "http://ftp.debian.org/debian"
+DISTRO_SEC_APT_SOURCE ?= "http://security.debian.org/"
 DISTRO_CONFIG_SCRIPT ?= "debian-configscript.sh"

--- a/meta-isar/recipes-core/images/files/multistrap.conf.in
+++ b/meta-isar/recipes-core/images/files/multistrap.conf.in
@@ -4,8 +4,8 @@
 [General]
 noauth=true
 unpack=true
-bootstrap=##DISTRO## Isar
-aptsources=##DISTRO##
+bootstrap=##DISTRO## ##DISTRO##-updates ##DISTRO##-security Isar
+aptsources=##DISTRO## ##DISTRO##-updates ##DISTRO##-security
 configscript=##CONFIG_SCRIPT##
 setupscript=##SETUP_SCRIPT##
 hookdir=##DIR_HOOKS##
@@ -15,6 +15,19 @@ source=##DISTRO_APT_SOURCE##
 suite=##DISTRO_SUITE##
 components=##DISTRO_COMPONENTS##
 packages=##IMAGE_PREINSTALL##
+omitdebsrc=true
+
+[##DISTRO##-updates]
+source=##DISTRO_APT_SOURCE##
+suite=##DISTRO_SUITE##-updates
+components=##DISTRO_COMPONENTS##
+omitdebsrc=true
+
+[##DISTRO##-security]
+source=##DISTRO_SEC_APT_SOURCE##
+suite=##DISTRO_SEC_SUITE##
+components=##DISTRO_COMPONENTS##
+#packages=##IMAGE_PREINSTALL##
 omitdebsrc=true
 
 [Isar]

--- a/meta-isar/recipes-core/images/isar-image-base.bb
+++ b/meta-isar/recipes-core/images/isar-image-base.bb
@@ -41,7 +41,9 @@ do_rootfs() {
     sed -e 's|##IMAGE_PREINSTALL##|${IMAGE_PREINSTALL}|g' \
         -e 's|##DISTRO##|${DISTRO}|g' \
         -e 's|##DISTRO_APT_SOURCE##|${DISTRO_APT_SOURCE}|g' \
+        -e 's|##DISTRO_SEC_APT_SOURCE##|${DISTRO_SEC_APT_SOURCE}|g' \
         -e 's|##DISTRO_SUITE##|${DISTRO_SUITE}|g' \
+        -e 's|##DISTRO_SEC_SUITE##|${DISTRO_SEC_SUITE}|g' \
         -e 's|##DISTRO_COMPONENTS##|${DISTRO_COMPONENTS}|g' \
         -e 's|##CONFIG_SCRIPT##|./'"$WORKDIR_REL"'/${DISTRO_CONFIG_SCRIPT}|g' \
         -e 's|##SETUP_SCRIPT##|./'"$WORKDIR_REL"'/setup.sh|g' \


### PR DESCRIPTION
To get a recent Debian image, distro "stretch" is not sufficient, but we need
stretch-updates plus stretch/updates from security.debian.org.

This patch is a WIP - it lacks corresponding changes to multistrap.conf.in from
recipes-devtools/buildchroot and the image recipes for Raspbian (and
older Debian versions?).

Based on an initial patch by Henning Schild <henning.schild@siemens.com>.

Signed-off-by: Gernot Hillier <gernot.hillier@siemens.com>